### PR TITLE
Implement basic decorators for storing Entity info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "reflect-metadata": "^0.1.13"
+      },
       "devDependencies": {
         "@types/jest": "^26.0.24",
         "@types/node": "^16.4.12",
@@ -5017,6 +5020,11 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9632,6 +9640,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "ts-jest": "^27.0.4",
     "tslint": "^6.1.3",
     "typescript": "^3.8.3"
+  },
+  "dependencies": {
+    "reflect-metadata": "^0.1.13"
   }
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,0 +1,45 @@
+import {Column} from './column';
+import {
+  ColumnConfig,
+  EntityConfig,
+  getColumnsFromClass,
+  getDatabaseConfig,
+  getEntityConfigFromClass,
+} from './decorators/decorators';
+import {Table} from './table';
+
+/**
+ * This is a temporary construct until I can build out support for
+ * Entity-specific DAOs. Any class with the @Database decorator should
+ * extend this class to add support for generic CRUD entity operations.
+ */
+export class AbstractDatabase {
+  initialize(): void {
+    const dbConfig = getDatabaseConfig(this);
+    if (!dbConfig) {
+      throw new Error('Classes that extend Database must have @Database decorator');
+    }
+
+    for (const e of dbConfig.entities) {
+      const entityConfig = getEntityConfigFromClass(e);
+      const cols = getColumnsFromClass(e);
+
+      console.log(`${e.name}`, cols);
+    }
+  }
+
+  add(entity: any) {}
+
+  createTableIfNotExists(entityConfig: EntityConfig, columnConfigs: ColumnConfig[]) {
+    const columnDefs: Column[] = columnConfigs.map(
+      c => ({name: c.name, type: undefined, constraints: []} as Column),
+    );
+    const table: Table = {
+      name: entityConfig.name,
+      columns: columnDefs,
+      constraints: [],
+    };
+  }
+}
+
+function isEntity() {}

--- a/src/database.ts
+++ b/src/database.ts
@@ -3,6 +3,7 @@ import {
   ColumnConfig,
   EntityConfig,
   getColumnsFromClass,
+  getConstraintConfigsFromClass,
   getDatabaseConfig,
   getEntityConfigFromClass,
 } from './decorators/decorators';
@@ -23,14 +24,16 @@ export class AbstractDatabase {
     for (const e of dbConfig.entities) {
       const entityConfig = getEntityConfigFromClass(e);
       const cols = getColumnsFromClass(e);
-
+      const constraintConfigs = getConstraintConfigsFromClass(e);
       console.log(`${e.name}`, cols);
+      console.log('constraints', constraintConfigs);
     }
   }
 
   add(entity: any) {}
 
   createTableIfNotExists(entityConfig: EntityConfig, columnConfigs: ColumnConfig[]) {
+    // TODO add constraints
     const columnDefs: Column[] = columnConfigs.map(
       c => ({name: c.name, type: undefined, constraints: []} as Column),
     );

--- a/src/decorators/decorators.test.ts
+++ b/src/decorators/decorators.test.ts
@@ -1,0 +1,30 @@
+import {ColumnTypeName} from '../column';
+import {Column, Database, Entity, getColumn} from './decorators';
+
+@Entity({name: 'book'})
+class Book {
+  @Column({name: 'title', type: ColumnTypeName.TEXT})
+  title: string;
+  @Column({name: 'author', type: ColumnTypeName.TEXT})
+  author: string;
+}
+
+@Database({name: 'nb', verison: '1', entities: [Book]})
+class JoshDB {
+
+}
+
+
+describe('@Column', () => {
+  test('should store ColumnConfig as property metadata', () => {
+    // const b = new Book();
+    // const config = getColumn(b, 'title');
+    // expect(config).toEqual({name: 'title', type: ColumnTypeName.TEXT});
+  });
+});
+
+describe('@Entity', () => {
+    test('should store entity in entity manager', () => {
+
+    });
+});

--- a/src/decorators/decorators.test.ts
+++ b/src/decorators/decorators.test.ts
@@ -1,5 +1,5 @@
 import {ColumnTypeName} from '../column';
-import {Column, Database, Entity} from './decorators';
+import {Column, Database, Entity, getColumns, getEntity} from './decorators';
 
 @Entity({name: 'book'})
 class Book {
@@ -9,22 +9,26 @@ class Book {
   author: string;
 }
 
-@Database({name: 'nb', verison: '1', entities: [Book]})
-class JoshDB {
-
-}
-
+@Database({name: 'nb', version: '1', entities: [Book]})
+class JoshDB {}
 
 describe('@Column', () => {
-  test('should store ColumnConfig as property metadata', () => {
-    // const b = new Book();
-    // const config = getColumn(b, 'title');
-    // expect(config).toEqual({name: 'title', type: ColumnTypeName.TEXT});
+  test('should store ColumnConfigs as metadata', () => {
+    const b = new Book();
+
+    const configs = getColumns(b);
+    expect(configs).toEqual([
+      {name: 'title', type: ColumnTypeName.TEXT},
+      {name: 'author', type: ColumnTypeName.TEXT},
+    ]);
   });
 });
 
-describe.only('@Entity', () => {
-    test('should store entity in entity manager', () => {
+describe('@Entity', () => {
+  test('should store EntityConfig as metadata', () => {
+    const b = new Book();
 
-    });
+    const config = getEntity(b);
+    expect(config).toEqual({name: 'book'});
+  });
 });

--- a/src/decorators/decorators.test.ts
+++ b/src/decorators/decorators.test.ts
@@ -1,80 +1,146 @@
 import {ColumnTypeName} from '../column';
-import {AbstractDatabase} from '../database';
-import {Column, Database, Entity, getColumns, getEntityConfig} from './decorators';
+import {ColumnConstraintType} from '../constraints';
+import {
+  Column,
+  Default,
+  Entity,
+  getColumns,
+  getConstraintConfigs,
+  getEntityConfig,
+  NotNull,
+  PrimaryKey,
+  Unique,
+} from './decorators';
 
-@Entity({name: 'book'})
-class Book {
-  @Column({name: 'title'})
-  title: string;
-  @Column({name: 'author'})
-  author: number;
-}
+describe('decorators', () => {
+  describe('@Column', () => {
+    it('should store ColumnConfigs as metadata', () => {
+      class Book {
+        @Column()
+        isbn: string;
 
-@Database({name: 'nb', version: '1', entities: [Book]})
-class JoshDB extends AbstractDatabase {}
+        @Column({name: 'title'})
+        title: string;
 
-describe.only('@Column', () => {
-  test('should store ColumnConfigs as metadata', () => {
-    const b = new Book();
+        @Column({name: 'author'})
+        author: number;
+      }
 
-    const configs = getColumns(b);
-    expect(configs).toEqual([
-      {name: 'title', type: {name: ColumnTypeName.TEXT, args: []}},
-      {name: 'author', type: {name: ColumnTypeName.INTEGER, args: []}},
-    ]);
+      const configs = getColumns(new Book());
+      expect(configs).toEqual([
+        {name: 'isbn', type: {name: ColumnTypeName.TEXT, args: []}},
+        {name: 'title', type: {name: ColumnTypeName.TEXT, args: []}},
+        {name: 'author', type: {name: ColumnTypeName.INTEGER, args: []}},
+      ]);
+    });
+
+    describe('ColumnType inference', () => {
+      it('should not infer when type is provided', () => {
+        class Test {
+          @Column({name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}})
+          prop: number;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}}]);
+      });
+
+      it('should infer INTEGER when property type is number', () => {
+        class Test {
+          @Column({name: 'prop'})
+          prop: number;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.INTEGER, args: []}}]);
+      });
+
+      it('should infer TEXT when property type is string', () => {
+        class Test {
+          @Column({name: 'prop'})
+          prop: string;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.TEXT, args: []}}]);
+      });
+
+      it('should infer BOOLEAN when property type is boolean', () => {
+        class Test {
+          @Column({name: 'prop'})
+          prop: boolean;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.BOOLEAN, args: []}}]);
+      });
+    });
   });
 
-  describe('ColumnType inference', () => {
-    it('should not infer when type is provided', () => {
-      class Test {
-        @Column({name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}})
-        prop: number;
-      }
-      const configs = getColumns(new Test());
-      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}}]);
-    });
-    
-    it('should infer INTEGER when property type is number', () => {
-      class Test {
-        @Column({name: 'prop'})
-        prop: number;
-      }
-      const configs = getColumns(new Test());
-      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.INTEGER, args: []}}]);
-    });
-
-    it('should infer TEXT when property type is string', () => {
-      class Test {
-        @Column({name: 'prop'})
-        prop: string;
-      }
-      const configs = getColumns(new Test());
-      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.TEXT, args: []}}]);
-    });
-
-    it('should infer BOOLEAN when property type is boolean', () => {
-      class Test {
-        @Column({name: 'prop'})
-        prop: boolean;
-      }
-      const configs = getColumns(new Test());
-      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.BOOLEAN, args: []}}]);
+  describe('@Entity', () => {
+    it('should store EntityConfig as metadata', () => {
+      @Entity({name: 'test'})
+      class Test {}
+      const config = getEntityConfig(new Test());
+      expect(config).toEqual({name: 'book'});
     });
   });
-});
 
-describe.only('@Entity', () => {
-  test('should store EntityConfig as metadata', () => {
-    const b = new Book();
+  describe('constraints', () => {
+    describe('@PrimaryKey', () => {
+      it('should store primary key ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @PrimaryKey()
+          prop: boolean;
+        }
 
-    const config = getEntityConfig(b);
-    expect(config).toEqual({name: 'book'});
-  });
-});
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.PRIMARY_KEY, columnName: 'prop', args: []},
+        ]);
+      });
+    });
 
-describe('@Database', () => {
-  test('should store EntityConfig as metadata', () => {
-    const db = new JoshDB();
-    db.initialize();
+    describe('@NotNull', () => {
+      it('should store not null ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @NotNull()
+          prop: boolean;
+        }
+
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.NOT_NULL, columnName: 'prop', args: []},
+        ]);
+      });
+    });
+
+    describe('@Unique', () => {
+      it('should store unique ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @Unique()
+          prop: boolean;
+        }
+
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.UNIQUE, columnName: 'prop', args: []},
+        ]);
+      });
+    });
+
+    describe('@Default', () => {
+      it('should store default ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @Default('true')
+          prop: boolean;
+        }
+
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.DEFAULT, columnName: 'prop', args: ['true']},
+        ]);
+      });
+    });
   });
 });

--- a/src/decorators/decorators.test.ts
+++ b/src/decorators/decorators.test.ts
@@ -1,34 +1,80 @@
 import {ColumnTypeName} from '../column';
-import {Column, Database, Entity, getColumns, getEntity} from './decorators';
+import {AbstractDatabase} from '../database';
+import {Column, Database, Entity, getColumns, getEntityConfig} from './decorators';
 
 @Entity({name: 'book'})
 class Book {
-  @Column({name: 'title', type: ColumnTypeName.TEXT})
+  @Column({name: 'title'})
   title: string;
-  @Column({name: 'author', type: ColumnTypeName.TEXT})
-  author: string;
+  @Column({name: 'author'})
+  author: number;
 }
 
 @Database({name: 'nb', version: '1', entities: [Book]})
-class JoshDB {}
+class JoshDB extends AbstractDatabase {}
 
-describe('@Column', () => {
+describe.only('@Column', () => {
   test('should store ColumnConfigs as metadata', () => {
     const b = new Book();
 
     const configs = getColumns(b);
     expect(configs).toEqual([
-      {name: 'title', type: ColumnTypeName.TEXT},
-      {name: 'author', type: ColumnTypeName.TEXT},
+      {name: 'title', type: {name: ColumnTypeName.TEXT, args: []}},
+      {name: 'author', type: {name: ColumnTypeName.INTEGER, args: []}},
     ]);
+  });
+
+  describe('ColumnType inference', () => {
+    it('should not infer when type is provided', () => {
+      class Test {
+        @Column({name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}})
+        prop: number;
+      }
+      const configs = getColumns(new Test());
+      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}}]);
+    });
+    
+    it('should infer INTEGER when property type is number', () => {
+      class Test {
+        @Column({name: 'prop'})
+        prop: number;
+      }
+      const configs = getColumns(new Test());
+      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.INTEGER, args: []}}]);
+    });
+
+    it('should infer TEXT when property type is string', () => {
+      class Test {
+        @Column({name: 'prop'})
+        prop: string;
+      }
+      const configs = getColumns(new Test());
+      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.TEXT, args: []}}]);
+    });
+
+    it('should infer BOOLEAN when property type is boolean', () => {
+      class Test {
+        @Column({name: 'prop'})
+        prop: boolean;
+      }
+      const configs = getColumns(new Test());
+      expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.BOOLEAN, args: []}}]);
+    });
   });
 });
 
-describe('@Entity', () => {
+describe.only('@Entity', () => {
   test('should store EntityConfig as metadata', () => {
     const b = new Book();
 
-    const config = getEntity(b);
+    const config = getEntityConfig(b);
     expect(config).toEqual({name: 'book'});
+  });
+});
+
+describe('@Database', () => {
+  test('should store EntityConfig as metadata', () => {
+    const db = new JoshDB();
+    db.initialize();
   });
 });

--- a/src/decorators/decorators.test.ts
+++ b/src/decorators/decorators.test.ts
@@ -1,5 +1,5 @@
 import {ColumnTypeName} from '../column';
-import {Column, Database, Entity, getColumn} from './decorators';
+import {Column, Database, Entity} from './decorators';
 
 @Entity({name: 'book'})
 class Book {
@@ -23,7 +23,7 @@ describe('@Column', () => {
   });
 });
 
-describe('@Entity', () => {
+describe.only('@Entity', () => {
     test('should store entity in entity manager', () => {
 
     });

--- a/src/decorators/decorators.ts
+++ b/src/decorators/decorators.ts
@@ -6,7 +6,7 @@ import {ENTITY_MANAGER} from '../entity-manager';
  * Borrowing the Type interface from Angular:
  * https://github.com/angular/angular/blob/6.1.6/packages/core/src/type.ts
  **/
- export interface Type<T> extends Function {
+export interface Type<T> extends Function {
   new (...args: any[]): T;
 }
 
@@ -42,7 +42,8 @@ export function Entity(config: EntityConfig): ClassDecorator {
 export function Column(config: ColumnConfig): PropertyDecorator {
   console.log('column decorator', config);
   return target => {
-    const columns: ColumnConfig[] = Reflect.getMetadata(METADATA_KEY_COLUMNS, target.constructor) ?? [];
+    const columns: ColumnConfig[] =
+      Reflect.getMetadata(METADATA_KEY_COLUMNS, target.constructor) ?? [];
     columns.push(config);
     Reflect.defineMetadata('columns', columns, target.constructor);
   };

--- a/src/decorators/decorators.ts
+++ b/src/decorators/decorators.ts
@@ -5,7 +5,7 @@ import {ENTITY_MANAGER} from '../entity-manager';
 /**
  * Borrowing the Type interface from Angular:
  * https://github.com/angular/angular/blob/6.1.6/packages/core/src/type.ts
- **/
+ */
 export interface Type<T> extends Function {
   new (...args: any[]): T;
 }
@@ -15,7 +15,7 @@ const METADATA_KEY_COLUMNS = 'columns';
 
 interface DatabaseConfig {
   name: string;
-  verison: string;
+  version: string;
   entities: Type<any>[];
 }
 
@@ -30,43 +30,35 @@ interface ColumnConfig {
   type: ColumnTypeName;
 }
 
+// TODO: Add support for adding constraint-like decorators (PrimaryKey, Unique, etc)
+
+/**
+ * An Entity decorator factory. This decorator should be attached to
+ * any class that is going to be persisted by the ORM.
+ */
 export function Entity(config: EntityConfig): ClassDecorator {
-  console.log('Entity decorator');
   return target => {
     Reflect.defineMetadata(METADATA_KEY_ENTITY, config, target);
-    const columns = Reflect.getMetadata(METADATA_KEY_COLUMNS, target);
-    console.log('entity constructor', columns);
   };
 }
 
 export function Column(config: ColumnConfig): PropertyDecorator {
-  console.log('column decorator', config);
   return target => {
     const columns: ColumnConfig[] =
       Reflect.getMetadata(METADATA_KEY_COLUMNS, target.constructor) ?? [];
     columns.push(config);
-    Reflect.defineMetadata('columns', columns, target.constructor);
+    Reflect.defineMetadata(METADATA_KEY_COLUMNS, columns, target.constructor);
   };
 }
 
-export function getColumn(target: any, propertyKey: string): ColumnConfig {
-  return Reflect.getMetadata('column', target, propertyKey);
+export function getColumns(target: any): ColumnConfig[] {
+  return Reflect.getMetadata(METADATA_KEY_COLUMNS, target.constructor);
 }
 
-export function Database(config: DatabaseConfig) {
-  const entities = config.entities;
-  console.log(entities);
-  const e = entities[0];
-  const meta = Reflect.getMetadata(METADATA_KEY_ENTITY, e);
-  const col = Reflect.getMetadata(METADATA_KEY_COLUMNS, e);
-  console.log(meta);
-  console.log(col);
-  // console.log('keys', Reflect.getMetadataKeys(meta));
+export function getEntity(target: any): ColumnConfig[] {
+  return Reflect.getMetadata(METADATA_KEY_ENTITY, target.constructor);
+}
 
-  // for each entity
-  // get table name
-  // get columns
-  // build table if doesn't exist
-  //
+export function Database(config: DatabaseConfig): ClassDecorator {
   return (constructor: Function) => {};
 }

--- a/src/decorators/decorators.ts
+++ b/src/decorators/decorators.ts
@@ -1,0 +1,56 @@
+import 'reflect-metadata';
+import {ColumnTypeName} from '../column';
+
+/** 
+ * Borrowing the Type interface from Angular:
+ * https://github.com/angular/angular/blob/6.1.6/packages/core/src/type.ts
+**/
+export interface Type<T> extends Function { new (...args: any[]): T; }
+
+interface DatabaseConfig {
+  name: string;
+  verison: string;
+  entities: Type<any>[];
+}
+
+interface EntityConfig {
+  name: string;
+}
+
+interface ColumnConfig {
+  name: string;
+  type: ColumnTypeName;
+}
+
+export function Entity(config: EntityConfig): ClassDecorator {
+  console.log('Entity decorator');
+  return Reflect.metadata('entity', config);
+}
+
+export function Column(config: ColumnConfig): PropertyDecorator {
+  console.log("column decorator", config);
+  return Reflect.metadata('column', config);
+}
+
+export function getColumn(target: any, propertyKey: string): ColumnConfig {
+  return Reflect.getMetadata('column', target, propertyKey);
+}
+
+export function Database(config: DatabaseConfig) {
+  console.log("DB");
+  const entities = config.entities;
+  console.log(entities);
+  const e = entities[0];
+  const meta = Reflect.getMetadata('entity', e);
+  const col = Reflect.getMetadata('column', e);
+  console.log(meta);
+  console.log(col);
+  console.log('keys', Reflect.getMetadataKeys(meta));
+
+  // for each entity
+  // get table name
+  // get columns
+  // build table if doesn't exist
+  // 
+  return (constructor: Function) =>{}
+}

--- a/src/entity-manager.ts
+++ b/src/entity-manager.ts
@@ -1,0 +1,10 @@
+class Entity {
+  name: string;
+  columns: Column[];
+}
+
+class EntityManager {
+  entities: Entity[];
+}
+
+export const ENTITY_MANAGER = new EntityManager();

--- a/src/entity-manager.ts
+++ b/src/entity-manager.ts
@@ -1,10 +1,21 @@
-class Entity {
-  name: string;
-  columns: Column[];
+import {Column} from './column';
+
+class EntityInfo {
+  id?: string;
+  name?: string;
+  columns?: Column[];
 }
 
 class EntityManager {
-  entities: Entity[];
+  entityInfo: Map<string, EntityInfo>;
+
+  /** Registers the Entity if it isn't already known. Returns the EntityInfo. */
+  registerEntity(id: string): EntityInfo {
+    const entry = this.entityInfo.get(id) ?? {};
+    entry.id = id;
+    this.entityInfo.set(id, entry);
+    return entry;
+  }
 }
 
 export const ENTITY_MANAGER = new EntityManager();

--- a/src/orm.ts
+++ b/src/orm.ts
@@ -13,20 +13,6 @@ class Orm {
   }
 }
 
-function generateCreateTableSqlForModel(
-  name: string,
-  columns: Column[],
-  columnConstraints: ColumnConstraint[],
-  tableConstraints: TableConstraint[],
-): string {
-  const columnDefinitionsSqls = columns.map(c => convertColumnToSql(c, columnConstraints));
-  const tableConstraintSqls = tableConstraints.map(t => convertTableConstraintToSql(t));
-
-  const defs = [...columnDefinitionsSqls, ...tableConstraintSqls].join(',');
-
-  return `CREATE TABLE IF NOT EXISTS ${name} (${defs})`;
-}
-
 interface Column {
   name: string;
   type: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
   }
 }


### PR DESCRIPTION
Implements the basic functionality for decorators used to define entities, columns, databases, and constraints. Also stubs out some early Database implementation because I can't focus on one feature at a time.