### PR TITLE
Implement basic decorators for storing Entity info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "reflect-metadata": "^0.1.13"
+      },
       "devDependencies": {
         "@types/jest": "^26.0.24",
         "@types/node": "^16.4.12",
@@ -5017,6 +5020,11 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9632,6 +9640,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "ts-jest": "^27.0.4",
     "tslint": "^6.1.3",
     "typescript": "^3.8.3"
+  },
+  "dependencies": {
+    "reflect-metadata": "^0.1.13"
   }
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,0 +1,48 @@
+import {Column} from './column';
+import {
+  ColumnConfig,
+  EntityConfig,
+  getColumnsFromClass,
+  getConstraintConfigsFromClass,
+  getDatabaseConfig,
+  getEntityConfigFromClass,
+} from './decorators/decorators';
+import {Table} from './table';
+
+/**
+ * This is a temporary construct until I can build out support for
+ * Entity-specific DAOs. Any class with the @Database decorator should
+ * extend this class to add support for generic CRUD entity operations.
+ */
+export class AbstractDatabase {
+  initialize(): void {
+    const dbConfig = getDatabaseConfig(this);
+    if (!dbConfig) {
+      throw new Error('Classes that extend Database must have @Database decorator');
+    }
+
+    for (const e of dbConfig.entities) {
+      const entityConfig = getEntityConfigFromClass(e);
+      const cols = getColumnsFromClass(e);
+      const constraintConfigs = getConstraintConfigsFromClass(e);
+      console.log(`${e.name}`, cols);
+      console.log('constraints', constraintConfigs);
+    }
+  }
+
+  add(entity: any) {}
+
+  createTableIfNotExists(entityConfig: EntityConfig, columnConfigs: ColumnConfig[]) {
+    // TODO add constraints
+    const columnDefs: Column[] = columnConfigs.map(
+      c => ({name: c.name, type: undefined, constraints: []} as Column),
+    );
+    const table: Table = {
+      name: entityConfig.name,
+      columns: columnDefs,
+      constraints: [],
+    };
+  }
+}
+
+function isEntity() {}

--- a/src/decorators/decorators.test.ts
+++ b/src/decorators/decorators.test.ts
@@ -1,0 +1,146 @@
+import {ColumnTypeName} from '../column';
+import {ColumnConstraintType} from '../constraints';
+import {
+  Column,
+  Default,
+  Entity,
+  getColumns,
+  getConstraintConfigs,
+  getEntityConfig,
+  NotNull,
+  PrimaryKey,
+  Unique,
+} from './decorators';
+
+describe('decorators', () => {
+  describe('@Column', () => {
+    it('should store ColumnConfigs as metadata', () => {
+      class Book {
+        @Column()
+        isbn: string;
+
+        @Column({name: 'title'})
+        title: string;
+
+        @Column({name: 'author'})
+        author: number;
+      }
+
+      const configs = getColumns(new Book());
+      expect(configs).toEqual([
+        {name: 'isbn', type: {name: ColumnTypeName.TEXT, args: []}},
+        {name: 'title', type: {name: ColumnTypeName.TEXT, args: []}},
+        {name: 'author', type: {name: ColumnTypeName.INTEGER, args: []}},
+      ]);
+    });
+
+    describe('ColumnType inference', () => {
+      it('should not infer when type is provided', () => {
+        class Test {
+          @Column({name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}})
+          prop: number;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.FLOAT, args: []}}]);
+      });
+
+      it('should infer INTEGER when property type is number', () => {
+        class Test {
+          @Column({name: 'prop'})
+          prop: number;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.INTEGER, args: []}}]);
+      });
+
+      it('should infer TEXT when property type is string', () => {
+        class Test {
+          @Column({name: 'prop'})
+          prop: string;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.TEXT, args: []}}]);
+      });
+
+      it('should infer BOOLEAN when property type is boolean', () => {
+        class Test {
+          @Column({name: 'prop'})
+          prop: boolean;
+        }
+        const configs = getColumns(new Test());
+        expect(configs).toEqual([{name: 'prop', type: {name: ColumnTypeName.BOOLEAN, args: []}}]);
+      });
+    });
+  });
+
+  describe('@Entity', () => {
+    it('should store EntityConfig as metadata', () => {
+      @Entity({name: 'test'})
+      class Test {}
+      const config = getEntityConfig(new Test());
+      expect(config).toEqual({name: 'book'});
+    });
+  });
+
+  describe('constraints', () => {
+    describe('@PrimaryKey', () => {
+      it('should store primary key ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @PrimaryKey()
+          prop: boolean;
+        }
+
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.PRIMARY_KEY, columnName: 'prop', args: []},
+        ]);
+      });
+    });
+
+    describe('@NotNull', () => {
+      it('should store not null ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @NotNull()
+          prop: boolean;
+        }
+
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.NOT_NULL, columnName: 'prop', args: []},
+        ]);
+      });
+    });
+
+    describe('@Unique', () => {
+      it('should store unique ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @Unique()
+          prop: boolean;
+        }
+
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.UNIQUE, columnName: 'prop', args: []},
+        ]);
+      });
+    });
+
+    describe('@Default', () => {
+      it('should store default ConstraintConfig as metadata', () => {
+        class Test {
+          @Column({})
+          @Default('true')
+          prop: boolean;
+        }
+
+        const configs = getConstraintConfigs(new Test());
+        expect(configs).toEqual([
+          {type: ColumnConstraintType.DEFAULT, columnName: 'prop', args: ['true']},
+        ]);
+      });
+    });
+  });
+});

--- a/src/decorators/decorators.ts
+++ b/src/decorators/decorators.ts
@@ -1,0 +1,171 @@
+import 'reflect-metadata';
+import {ColumnType, ColumnTypeName} from '../column';
+import {ColumnConstraintType, TableConstraintType} from '../constraints';
+import {ENTITY_MANAGER} from '../entity-manager';
+
+/**
+ * Borrowing the Type interface from Angular:
+ * https://github.com/angular/angular/blob/6.1.6/packages/core/src/type.ts
+ */
+export interface Type<T> extends Function {
+  new (...args: any[]): T;
+}
+
+const METADATA_KEY_DATABASE = 'database';
+const METADATA_KEY_ENTITY = 'entity';
+const METADATA_KEY_COLUMNS = 'columns';
+const METADATA_KEY_CONSTRAINTS = 'constraints';
+
+interface DatabaseConfig {
+  name: string;
+  version: string;
+  entities: Type<any>[];
+}
+
+export interface EntityConfig {
+  name?: string;
+}
+
+export interface ColumnConfig {
+  name?: string;
+  type?: ColumnType;
+}
+
+interface ConstraintConfig {
+  type: ColumnConstraintType | TableConstraintType;
+  columnName: string;
+  args: any[];
+}
+
+// TODO: Add support for adding constraint-like decorators (PrimaryKey, Unique, etc)
+
+/**
+ * An Entity decorator factory. This decorator should be attached to
+ * any class that is going to be persisted by the ORM.
+ */
+export function Entity(config: EntityConfig): ClassDecorator {
+  return target => {
+    Reflect.defineMetadata(METADATA_KEY_ENTITY, config, target);
+  };
+}
+
+export function Column(config?: ColumnConfig): PropertyDecorator {
+  return (target, propertyKey) => {
+    const columnConfig = config ?? {};
+    if (!columnConfig.name) {
+      columnConfig.name = propertyKey.toString();
+    }
+    if (!columnConfig.type) {
+      const propertyType = Reflect.getMetadata('design:type', target, propertyKey);
+      columnConfig.type = inferColumnType(propertyType.name);
+    }
+
+    addColumnConfigToMetadata(columnConfig, target);
+  };
+}
+
+export function PrimaryKey(): PropertyDecorator {
+  return (target, propertyKey) => {
+    const config = {
+      type: ColumnConstraintType.PRIMARY_KEY,
+      columnName: propertyKey.toString(),
+      args: [],
+    };
+    addConstraintConfigToMetadata(config, target);
+  };
+}
+
+export function NotNull(): PropertyDecorator {
+  return (target, propertyKey) => {
+    const config = {
+      type: ColumnConstraintType.NOT_NULL,
+      columnName: propertyKey.toString(),
+      args: [],
+    };
+    addConstraintConfigToMetadata(config, target);
+  };
+}
+
+export function Unique(): PropertyDecorator {
+  return (target, propertyKey) => {
+    const config = {
+      type: ColumnConstraintType.UNIQUE,
+      columnName: propertyKey.toString(),
+      args: [],
+    };
+    addConstraintConfigToMetadata(config, target);
+  };
+}
+
+export function Default(expression: string): PropertyDecorator {
+  return (target, propertyKey) => {
+    const config = {
+      type: ColumnConstraintType.DEFAULT,
+      columnName: propertyKey.toString(),
+      args: [expression],
+    };
+    addConstraintConfigToMetadata(config, target);
+  };
+}
+
+function addConstraintConfigToMetadata(config: ConstraintConfig, target: any): void {
+  const constraints: ConstraintConfig[] =
+    Reflect.getMetadata(METADATA_KEY_CONSTRAINTS, target.constructor) ?? [];
+  constraints.push(config);
+  Reflect.defineMetadata(METADATA_KEY_CONSTRAINTS, constraints, target.constructor);
+}
+
+function addColumnConfigToMetadata(config: ColumnConfig, target: any): void {
+  const columns: ColumnConfig[] =
+    Reflect.getMetadata(METADATA_KEY_COLUMNS, target.constructor) ?? [];
+  columns.push(config);
+  Reflect.defineMetadata(METADATA_KEY_COLUMNS, columns, target.constructor);
+}
+
+export function getConstraintConfigs(target: any): ConstraintConfig[] {
+  return Reflect.getMetadata(METADATA_KEY_CONSTRAINTS, target.constructor);
+}
+
+export function getConstraintConfigsFromClass(target: Type<any>): ConstraintConfig[] {
+  return Reflect.getMetadata(METADATA_KEY_CONSTRAINTS, target);
+}
+
+export function getColumns(target: any): ColumnConfig[] {
+  return Reflect.getMetadata(METADATA_KEY_COLUMNS, target.constructor);
+}
+
+export function getColumnsFromClass(target: Type<any>): ColumnConfig[] {
+  return Reflect.getMetadata(METADATA_KEY_COLUMNS, target);
+}
+
+export function getEntityConfig(target: any): EntityConfig {
+  return Reflect.getMetadata(METADATA_KEY_ENTITY, target.constructor);
+}
+
+export function getEntityConfigFromClass(target: Type<any>): EntityConfig {
+  return Reflect.getMetadata(METADATA_KEY_ENTITY, target);
+}
+
+export function getDatabaseConfig(target: any): DatabaseConfig {
+  return Reflect.getMetadata(METADATA_KEY_DATABASE, target.constructor);
+}
+
+export function Database(config: DatabaseConfig): ClassDecorator {
+  return target => {
+    Reflect.defineMetadata(METADATA_KEY_DATABASE, config, target);
+  };
+}
+
+/** Tries to infer a ColumnType from the provided type. */
+function inferColumnType(type: string): ColumnType {
+  switch (type) {
+    case Number.name:
+      return {name: ColumnTypeName.INTEGER, args: []};
+    case String.name:
+      return {name: ColumnTypeName.TEXT, args: []};
+    case Boolean.name:
+      return {name: ColumnTypeName.BOOLEAN, args: []};
+    default:
+      throw new Error(`Unable to infer ColumnType from provided type ${type}`);
+  }
+}

--- a/src/entity-manager.ts
+++ b/src/entity-manager.ts
@@ -1,0 +1,21 @@
+import {Column} from './column';
+
+class EntityInfo {
+  id?: string;
+  name?: string;
+  columns?: Column[];
+}
+
+class EntityManager {
+  entityInfo: Map<string, EntityInfo>;
+
+  /** Registers the Entity if it isn't already known. Returns the EntityInfo. */
+  registerEntity(id: string): EntityInfo {
+    const entry = this.entityInfo.get(id) ?? {};
+    entry.id = id;
+    this.entityInfo.set(id, entry);
+    return entry;
+  }
+}
+
+export const ENTITY_MANAGER = new EntityManager();

--- a/src/orm.ts
+++ b/src/orm.ts
@@ -13,20 +13,6 @@ class Orm {
   }
 }
 
-function generateCreateTableSqlForModel(
-  name: string,
-  columns: Column[],
-  columnConstraints: ColumnConstraint[],
-  tableConstraints: TableConstraint[],
-): string {
-  const columnDefinitionsSqls = columns.map(c => convertColumnToSql(c, columnConstraints));
-  const tableConstraintSqls = tableConstraints.map(t => convertTableConstraintToSql(t));
-
-  const defs = [...columnDefinitionsSqls, ...tableConstraintSqls].join(',');
-
-  return `CREATE TABLE IF NOT EXISTS ${name} (${defs})`;
-}
-
 interface Column {
   name: string;
   type: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+  }
+}


### PR DESCRIPTION
Implements the basic functionality for decorators used to define entities, columns, databases, and constraints. Also stubs out some early Database implementation because I can't focus on one feature at a time.

(This was remerged cause i forgot to squash...oops)